### PR TITLE
SOP-428: Prepares for the upgrade to PHP7.2.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-php_version: 7.1
+php_version: 7.2
 php_xdebug_extension: 'xdebug.so'
 
 php_xdebug_remote_enable: on


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-428

This was removed from _everywhere_ once we updated to PHP7.1 as the repo was hardcoded too much (and named ansible-php5-xdebug ... which we've since changed) ~ currently only OPI implement it, so as long as OPI can use 7.2 then we can change this default ... and then slowly roll out the `php_version` in a PR for all the brand sites.

**NOTE**: This is only changing the default, so this is minor ~ it doesn't even have to be merged as long as `php_version` is implemented in the brand sites vagrant.yml file.

Should be merged together with https://github.com/webhop/ansible-apache2-pagespeed/pull/34 and https://github.com/webhop/ansible-php7/pull/1